### PR TITLE
File search after pushing enter key

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -146,7 +146,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.fileSearch = QtWidgets.QLineEdit()
         self.fileSearch.setPlaceholderText(self.tr("Search Filename"))
-        self.fileSearch.textChanged.connect(self.fileSearchChanged)
+        self.fileSearch.returnPressed.connect(self.fileSearchChanged)
         self.fileListWidget = QtWidgets.QListWidget()
         self.fileListWidget.itemSelectionChanged.connect(
             self.fileSelectionChanged


### PR DESCRIPTION
This commit is for performance reason. When thousands of files is searched with textChanged, it would be slow. I suggested use returnPassed event instead of textChanged event.